### PR TITLE
Added globalErrors and fieldErrors to Errors response

### DIFF
--- a/core/src/main/groovy/org/grails/gorm/graphql/response/GraphQLLocalResolver.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/response/GraphQLLocalResolver.groovy
@@ -1,0 +1,5 @@
+package org.grails.gorm.graphql.response
+
+interface GraphQLLocalResolver {
+    Locale resolveLocale()
+}


### PR DESCRIPTION
The Error objectType in the schema was a List of field:message errors, but org.springframework.validation.Errors could have globalErrors as well. Added these and added a possibility to retrieve the locale through a localeResolver. 