### PR TITLE
Update operations.adoc

### DIFF
--- a/docs/src/main/docs/guide/customizations/operations.adoc
+++ b/docs/src/main/docs/guide/customizations/operations.adoc
@@ -13,7 +13,9 @@ static graphql = GraphQLMapping.build {
     //or
     //operations.get
     //operations.list
+    //operations.count
     //operations.create
+    //operations.update
     //operations.delete
 }
 ----


### PR DESCRIPTION
I wanted to make my API readonly but the documentation was missing the update operation and I had to search for it in the reference documentation. It would be much better if all operations were listed in that example.

I've added count and update operations to make the list exhaustive.

Note: I'm not sure why the line 264 is shown in the diff. I didn't edit it.