### PR TITLE
Use an artifactId that does not clash with the gorm subproject

### DIFF
--- a/docs/src/main/docs/guide/installation.adoc
+++ b/docs/src/main/docs/guide/installation.adoc
@@ -4,7 +4,7 @@ To use this library in your project, add the following dependency to the
 For Grails applications
 
 [source,groovy,subs="attributes"]
-compile "org.grails.plugins:gorm-graphql:{version}"
+compile "org.grails.plugins:gorm-graphql-plugin:{version}"
 
 For standalone projects
 

--- a/gradle/common-publishing.gradle
+++ b/gradle/common-publishing.gradle
@@ -87,7 +87,7 @@ publishing {
     publications {
         maven(MavenPublication) {
             if(isGrailsPlugin) {
-                artifactId( project.name - 'plugin-gorm-' )
+                artifactId( 'gorm-graphql-plugin' )
             }
             else if(project.name.contains('/')) {
                 artifactId( project.name.substring(project.name.indexOf('/') + 1) )

--- a/gradle/common-publishing.gradle
+++ b/gradle/common-publishing.gradle
@@ -87,7 +87,7 @@ publishing {
     publications {
         maven(MavenPublication) {
             if(isGrailsPlugin) {
-                artifactId( project.name - 'grails-plugin-' )
+                artifactId( project.name - 'plugin-gorm-' )
             }
             else if(project.name.contains('/')) {
                 artifactId( project.name.substring(project.name.indexOf('/') + 1) )


### PR DESCRIPTION
Workaround for grails/gorm-graphql#17. 

This probably isn't the perfect solution (@kirpi4ik makes some good points in the issue discussion) but it would be nice to get at least a snapshot version released that works with Grails 4.x

This changes the plugin dependency from
`"org.grails.plugins:gorm-graphql:2.0.0.BUILD-SNAPSHOT"`
to
`"org.grails.plugins:grails-graphql:2.0.0.BUILD-SNAPSHOT"`

and therefore prevents one of the `gorm-graphql-xxx.jar` files from being overwritten when producing a project war. 