### PR TITLE
Support for Union properties

### DIFF
--- a/core/src/main/groovy/org/grails/gorm/graphql/Schema.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/Schema.groovy
@@ -488,7 +488,7 @@ class Schema {
             }
             if (mapping.additionalUnions) {
                 for (UnionGraphQLProperty union : mapping.additionalUnions) {
-                    additionalTypes.addAll(union.getUnionTypes())
+                    additionalTypes.addAll(union.unionTypes)
                 }
             } else {
                 additionalTypes.add(typeManager.getQueryType(entity, GraphQLPropertyType.OUTPUT))

--- a/core/src/main/groovy/org/grails/gorm/graphql/Schema.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/Schema.groovy
@@ -16,6 +16,7 @@ import org.grails.gorm.graphql.entity.dsl.GraphQLMapping
 import org.grails.gorm.graphql.entity.operations.CustomOperation
 import org.grails.gorm.graphql.entity.operations.ListOperation
 import org.grails.gorm.graphql.entity.operations.ProvidedOperation
+import org.grails.gorm.graphql.entity.property.impl.UnionGraphQLProperty
 import org.grails.gorm.graphql.entity.property.manager.DefaultGraphQLDomainPropertyManager
 import org.grails.gorm.graphql.entity.property.manager.GraphQLDomainPropertyManager
 import org.grails.gorm.graphql.fetcher.BindingGormDataFetcher
@@ -253,6 +254,8 @@ class Schema {
                         childrenNotMapped.add(entity)
                     }
                     continue
+                } else if (mapping.additionalUnions) {
+                    childrenNotMapped.add(entity)
                 } else if (!mapping.operations.all.enabled) {
                     continue
                 }
@@ -483,8 +486,14 @@ class Schema {
             if (mapping == null) {
                 continue
             }
+            if (mapping.additionalUnions) {
+                for (UnionGraphQLProperty union : mapping.additionalUnions) {
+                    additionalTypes.addAll(union.getUnionTypes())
+                }
+            } else {
+                additionalTypes.add(typeManager.getQueryType(entity, GraphQLPropertyType.OUTPUT))
+            }
 
-            additionalTypes.add(typeManager.getQueryType(entity, GraphQLPropertyType.OUTPUT))
         }
 
         for (GraphQLSchemaInterceptor schemaInterceptor: interceptorManager.interceptors) {

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/dsl/GraphQLMapping.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/dsl/GraphQLMapping.groovy
@@ -10,7 +10,10 @@ import org.grails.gorm.graphql.entity.operations.CustomOperation
 import org.grails.gorm.graphql.entity.operations.OperationType
 import org.grails.gorm.graphql.entity.operations.SimpleOperation
 import org.grails.gorm.graphql.entity.property.impl.ComplexGraphQLProperty
+import org.grails.gorm.graphql.entity.property.impl.ComplexUnionGraphQLProperty
 import org.grails.gorm.graphql.entity.property.impl.CustomGraphQLProperty
+import org.grails.gorm.graphql.entity.property.impl.SimpleUnionGraphQLProperty
+import org.grails.gorm.graphql.entity.property.impl.UnionGraphQLProperty
 import org.grails.gorm.graphql.entity.property.impl.SimpleGraphQLProperty
 import org.grails.gorm.graphql.response.pagination.PaginatedType
 import org.springframework.beans.MutablePropertyValues
@@ -40,6 +43,7 @@ import org.springframework.validation.DataBinder
 class GraphQLMapping implements Describable<GraphQLMapping>, Deprecatable<GraphQLMapping>, ExecutesClosures {
 
     private List<CustomGraphQLProperty> additional = []
+    private List<UnionGraphQLProperty> additionalUnions = []
     private Map<String, GraphQLPropertyMapping> propertyMappings = [:]
     Set<String> excluded = [] as Set
     Operations operations = new Operations()
@@ -48,6 +52,10 @@ class GraphQLMapping implements Describable<GraphQLMapping>, Deprecatable<GraphQ
 
     List<CustomGraphQLProperty> getAdditional() {
         new ArrayList<CustomGraphQLProperty>(additional)
+    }
+
+    List<UnionGraphQLProperty> getAdditionalUnions() {
+        new ArrayList<UnionGraphQLProperty>(additionalUnions)
     }
 
     Map<String, GraphQLPropertyMapping> getPropertyMappings() {
@@ -126,6 +134,40 @@ class GraphQLMapping implements Describable<GraphQLMapping>, Deprecatable<GraphQ
      */
     void add(String name, String typeName, @DelegatesTo(value = ComplexGraphQLProperty, strategy = Closure.DELEGATE_ONLY) Closure closure) {
         CustomGraphQLProperty property = new ComplexGraphQLProperty().name(name).typeName(typeName)
+        withDelegate(closure, property)
+        add(property)
+    }
+
+    /**
+     * Add a new Union property to be included in the schema.
+     * @param property The Union property to include
+     */
+    void add(UnionGraphQLProperty property) {
+        property.validate()
+        additionalUnions.add(property)
+    }
+
+    /**
+     * Add a new Union property to be included in the schema.
+     * @param name The name of the property to include
+     * @param typeName The name of the custom Union type being created
+     * @param closure A closure to further configure the property
+     */
+    void addUnion(String name, String typeName, @DelegatesTo(value = ComplexUnionGraphQLProperty, strategy = Closure.DELEGATE_ONLY) Closure closure) {
+        UnionGraphQLProperty property = new ComplexUnionGraphQLProperty().name(name).typeName(typeName)
+        withDelegate(closure, property)
+        add(property)
+    }
+
+    /**
+     * Add a new Union property to be included in the schema.
+     * @param name The name of the property to include
+     * @param typeName The name of the custom Union type being created
+     * @param unionedTypes A collection of potential return types
+     * @param closure A closure to further configure the property
+     */
+    void addUnion(String name, String typeName, List<Class> unionedTypes, @DelegatesTo(value = SimpleUnionGraphQLProperty, strategy = Closure.DELEGATE_ONLY) Closure closure) {
+        UnionGraphQLProperty property = new SimpleUnionGraphQLProperty().name(name).typeName(typeName).setUnionTypes(unionedTypes.toSet())
         withDelegate(closure, property)
         add(property)
     }

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/dsl/helpers/CustomTyped.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/dsl/helpers/CustomTyped.groovy
@@ -1,0 +1,85 @@
+package org.grails.gorm.graphql.entity.dsl.helpers
+
+
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLOutputType
+import groovy.transform.CompileStatic
+import org.grails.datastore.mapping.model.MappingContext
+import org.grails.gorm.graphql.entity.fields.ComplexField
+import org.grails.gorm.graphql.entity.fields.Field
+import org.grails.gorm.graphql.entity.fields.SimpleField
+import org.grails.gorm.graphql.types.GraphQLTypeManager
+
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
+
+/**
+ * Decorates a class with the ability to build a custom type
+ *
+ * @param <T> The implementing class
+ * @author James Kleeh
+ * @since 1.0.0
+ */
+@CompileStatic
+trait CustomTyped<T> extends ExecutesClosures {
+    List<Field> fields = []
+
+    boolean defaultNull = true
+
+    T defaultNull(boolean defaultNull) {
+        this.defaultNull = defaultNull
+        (T)this
+    }
+
+    /**
+     * Builds a custom object returnType if the supplied return returnType is a Map
+     *
+     * @param typeManager The returnType manager
+     * @param mappingContext The mapping context
+     * @return The custom returnType
+     */
+    GraphQLOutputType buildCustomType(String name, GraphQLTypeManager typeManager, MappingContext mappingContext) {
+        GraphQLObjectType.Builder builder = GraphQLObjectType.newObject()
+                .name(name)
+
+        for (Field field: fields) {
+            if (field.output) {
+                builder.field(newFieldDefinition()
+                        .name(field.name)
+                        .description(field.description)
+                        .deprecate(field.deprecationReason)
+                        .type(field.getType(typeManager, mappingContext)))
+            }
+        }
+        builder.build()
+    }
+
+    private void handleField(Closure closure, Field field) {
+        field.nullable(defaultNull)
+        withDelegate(closure, (Object)field)
+        handleField(field)
+    }
+
+    private void handleField(Field field) {
+        field.validate()
+        fields.add(field)
+    }
+
+    void field(String name, List<Class> type, @DelegatesTo(value = SimpleField, strategy = Closure.DELEGATE_ONLY) Closure closure = null) {
+        Field field = new SimpleField().name(name).returns(type)
+        handleField(closure, field)
+    }
+
+    void field(String name, Class type, @DelegatesTo(value = SimpleField, strategy = Closure.DELEGATE_ONLY) Closure closure = null) {
+        Field field = new SimpleField().name(name).returns(type)
+        handleField(closure, field)
+    }
+
+    void field(String name, String typeName, @DelegatesTo(value = ComplexField, strategy = Closure.DELEGATE_ONLY) Closure closure) {
+        Field field = new ComplexField().name(name).typeName(typeName)
+        handleField(closure, field)
+    }
+
+    void field(ComplexField field) {
+        handleField(field)
+    }
+}

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/dsl/helpers/CustomTyped.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/dsl/helpers/CustomTyped.groovy
@@ -1,6 +1,5 @@
 package org.grails.gorm.graphql.entity.dsl.helpers
 
-
 import graphql.schema.GraphQLObjectType
 import graphql.schema.GraphQLOutputType
 import groovy.transform.CompileStatic

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/ComplexUnionGraphQLProperty.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/ComplexUnionGraphQLProperty.groovy
@@ -25,7 +25,6 @@ class ComplexUnionGraphQLProperty extends UnionGraphQLProperty<ComplexUnionGraph
     private Map<Class, CustomTyped> unionTypedMap = [:]
     private Set<GraphQLObjectType> graphQLTypesMap = [] as Set<GraphQLObjectType>
 
-
     ComplexUnionGraphQLProperty typeName(String typeName) {
         this.typeName = typeName
         this
@@ -46,12 +45,12 @@ class ComplexUnionGraphQLProperty extends UnionGraphQLProperty<ComplexUnionGraph
                 .typeResolver(new TypeResolver() {
                     @Override
                     GraphQLObjectType getType(TypeResolutionEnvironment env) {
-                        String resolvedName = typeManager.namingConvention.getType(env.getObject().class.simpleName, propertyType)
+                        String resolvedName = typeManager.namingConvention.getType(env.object.class.simpleName, propertyType)
                         (GraphQLObjectType)env.schema.getType(resolvedName)
                     }
                 })
 
-        for(GraphQLObjectType possibleType : graphQLTypesMap) {
+        for (GraphQLObjectType possibleType : graphQLTypesMap) {
             obj.possibleType(possibleType)
         }
 
@@ -94,7 +93,7 @@ class ComplexUnionGraphQLProperty extends UnionGraphQLProperty<ComplexUnionGraph
         if (typeName == null) {
             throw new IllegalArgumentException('The type name must be specified for custom properties with a complex type')
         }
-        for(CustomTyped typed : unionTypedMap.values()) {
+        for (CustomTyped typed : unionTypedMap.values()) {
             if (typed.fields.empty) {
                 throw new IllegalArgumentException("$name: At least 1 field is required for creating a custom property")
             }

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/ComplexUnionGraphQLProperty.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/ComplexUnionGraphQLProperty.groovy
@@ -1,0 +1,103 @@
+package org.grails.gorm.graphql.entity.property.impl
+
+import graphql.TypeResolutionEnvironment
+import graphql.schema.*
+import groovy.transform.AutoClone
+import groovy.transform.CompileStatic
+import org.grails.gorm.graphql.entity.dsl.helpers.CustomTyped
+import org.grails.gorm.graphql.entity.dsl.helpers.ExecutesClosures
+import org.grails.gorm.graphql.types.GraphQLPropertyType
+import org.grails.gorm.graphql.types.GraphQLTypeManager
+
+import static graphql.schema.GraphQLUnionType.newUnionType
+
+/**
+ * Used to represent a custom union property consisting of custom unioned types
+ *
+ * @author James Hardwick
+ * @since 2.0.2
+ */
+@AutoClone
+@CompileStatic
+class ComplexUnionGraphQLProperty extends UnionGraphQLProperty<ComplexUnionGraphQLProperty> implements ExecutesClosures {
+
+    String typeName
+    private Map<Class, CustomTyped> unionTypedMap = [:]
+    private Set<GraphQLObjectType> graphQLTypesMap = [] as Set<GraphQLObjectType>
+
+
+    ComplexUnionGraphQLProperty typeName(String typeName) {
+        this.typeName = typeName
+        this
+    }
+
+    @Override
+    GraphQLType getGraphQLType(GraphQLTypeManager typeManager, GraphQLPropertyType propertyType) {
+
+        unionTypedMap.each { k, v ->
+            String name = typeManager.namingConvention.getType(k.simpleName, propertyType)
+            graphQLTypesMap.add((GraphQLObjectType)v.buildCustomType(name, typeManager, mappingContext))
+        }
+
+        String name = typeManager.namingConvention.getType(typeName, propertyType)
+        GraphQLUnionType.Builder obj = newUnionType()
+                .name(name)
+                .description(description)
+                .typeResolver(new TypeResolver() {
+                    @Override
+                    GraphQLObjectType getType(TypeResolutionEnvironment env) {
+                        String resolvedName = typeManager.namingConvention.getType(env.getObject().class.simpleName, propertyType)
+                        (GraphQLObjectType)env.schema.getType(resolvedName)
+                    }
+                })
+
+        for(GraphQLObjectType possibleType : graphQLTypesMap) {
+            obj.possibleType(possibleType)
+        }
+
+        GraphQLOutputType type = obj.build()
+        if (collection) {
+            type = GraphQLList.list(type)
+        }
+        type
+    }
+
+    @Override
+    Set<GraphQLObjectType> getUnionTypes() {
+        graphQLTypesMap
+    }
+
+    /**
+     * Defines a custom type object to be used as part of a union, and as such, changes this property into a union type.
+     * <p>
+     * Per the latest GraphQL Spec, union member types must all be of an Object base type. Scalar, Interface, and Union
+     * types may not be member types of a union. Similarly, wrapping types must not be member types of a union. Unions
+     * are also not currently considered valid input. Defining this property as a union will automatically set its
+     * {@link CustomGraphQLProperty#input} property to false.
+     * <p>
+     *
+     * @param type A concrete class type that may ultimately be returned by this properties data fetcher
+     * @param closure A closure for defining the custom type
+     *
+     * @see {<a href="http://spec.graphql.org/June2018/#sec-Unions">GraphQL June 2018 Spec - Unions</a>}
+     * @see {<a href="https://github.com/graphql/graphql-spec/issues/488">[RFC] GraphQL Input Union type</a>}
+     */
+    void type(Class type, @DelegatesTo(value = CustomTyped, strategy = Closure.DELEGATE_ONLY) Closure closure) {
+        CustomTyped<CustomTyped> typed = new Object().withTraits(CustomTyped)
+        withDelegate(closure, typed)
+        unionTypedMap.put(type, typed)
+    }
+
+    void validate() {
+        super.validate()
+
+        if (typeName == null) {
+            throw new IllegalArgumentException('The type name must be specified for custom properties with a complex type')
+        }
+        for(CustomTyped typed : unionTypedMap.values()) {
+            if (typed.fields.empty) {
+                throw new IllegalArgumentException("$name: At least 1 field is required for creating a custom property")
+            }
+        }
+    }
+}

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/SimpleUnionGraphQLProperty.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/SimpleUnionGraphQLProperty.groovy
@@ -5,8 +5,6 @@ import graphql.schema.*
 import groovy.transform.AutoClone
 import groovy.transform.CompileStatic
 import org.grails.datastore.mapping.model.PersistentEntity
-import org.grails.gorm.graphql.entity.dsl.helpers.CustomTyped
-import org.grails.gorm.graphql.entity.dsl.helpers.Typed
 import org.grails.gorm.graphql.types.GraphQLPropertyType
 import org.grails.gorm.graphql.types.GraphQLTypeManager
 
@@ -25,7 +23,6 @@ class SimpleUnionGraphQLProperty extends UnionGraphQLProperty<SimpleUnionGraphQL
     String typeName
     private Set<Class> unionedTypes = []
     private Set<GraphQLObjectType> graphQLTypesMap = []
-
 
     SimpleUnionGraphQLProperty typeName(String typeName) {
         this.typeName = typeName
@@ -51,12 +48,12 @@ class SimpleUnionGraphQLProperty extends UnionGraphQLProperty<SimpleUnionGraphQL
                 .typeResolver(new TypeResolver() {
                     @Override
                     GraphQLObjectType getType(TypeResolutionEnvironment env) {
-                        String resolvedName = typeManager.namingConvention.getType(env.getObject().class.simpleName, propertyType)
+                        String resolvedName = typeManager.namingConvention.getType(env.object.class.simpleName, propertyType)
                         (GraphQLObjectType)env.schema.getType(resolvedName)
                     }
                 })
 
-        for(GraphQLObjectType possibleType : graphQLTypesMap) {
+        for (GraphQLObjectType possibleType : graphQLTypesMap) {
             obj.possibleType(possibleType)
         }
 

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/SimpleUnionGraphQLProperty.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/SimpleUnionGraphQLProperty.groovy
@@ -1,0 +1,82 @@
+package org.grails.gorm.graphql.entity.property.impl
+
+import graphql.TypeResolutionEnvironment
+import graphql.schema.*
+import groovy.transform.AutoClone
+import groovy.transform.CompileStatic
+import org.grails.datastore.mapping.model.PersistentEntity
+import org.grails.gorm.graphql.entity.dsl.helpers.CustomTyped
+import org.grails.gorm.graphql.entity.dsl.helpers.Typed
+import org.grails.gorm.graphql.types.GraphQLPropertyType
+import org.grails.gorm.graphql.types.GraphQLTypeManager
+
+import static graphql.schema.GraphQLUnionType.newUnionType
+
+/**
+ * Used to represent a custom union property consisting of simple unioned types
+ *
+ * @author James Hardwick
+ * @since 2.0.2
+ */
+@AutoClone
+@CompileStatic
+class SimpleUnionGraphQLProperty extends UnionGraphQLProperty<SimpleUnionGraphQLProperty> {
+
+    String typeName
+    private Set<Class> unionedTypes = []
+    private Set<GraphQLObjectType> graphQLTypesMap = []
+
+
+    SimpleUnionGraphQLProperty typeName(String typeName) {
+        this.typeName = typeName
+        this
+    }
+
+    SimpleUnionGraphQLProperty setUnionTypes(Set<Class> classes) {
+        this.unionedTypes = classes
+        this
+    }
+
+    @Override
+    GraphQLType getGraphQLType(GraphQLTypeManager typeManager, GraphQLPropertyType propertyType) {
+        unionedTypes.each { type ->
+            PersistentEntity entity = mappingContext?.getPersistentEntity(type.name)
+            graphQLTypesMap.add((GraphQLObjectType)typeManager.getQueryType(entity, propertyType))
+        }
+
+        String name = typeManager.namingConvention.getType(typeName, propertyType)
+        GraphQLUnionType.Builder obj = newUnionType()
+                .name(name)
+                .description(description)
+                .typeResolver(new TypeResolver() {
+                    @Override
+                    GraphQLObjectType getType(TypeResolutionEnvironment env) {
+                        String resolvedName = typeManager.namingConvention.getType(env.getObject().class.simpleName, propertyType)
+                        (GraphQLObjectType)env.schema.getType(resolvedName)
+                    }
+                })
+
+        for(GraphQLObjectType possibleType : graphQLTypesMap) {
+            obj.possibleType(possibleType)
+        }
+
+        GraphQLOutputType type = obj.build()
+        if (collection) {
+            type = GraphQLList.list(type)
+        }
+        type
+    }
+
+    @Override
+    Set<GraphQLObjectType> getUnionTypes() {
+        graphQLTypesMap
+    }
+
+    void validate() {
+        super.validate()
+
+        if (typeName == null) {
+            throw new IllegalArgumentException('The type name must be specified for custom properties with a complex type')
+        }
+    }
+}

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/UnionGraphQLProperty.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/UnionGraphQLProperty.groovy
@@ -1,0 +1,67 @@
+package org.grails.gorm.graphql.entity.property.impl
+
+import graphql.schema.DataFetcher
+import graphql.schema.GraphQLType
+import groovy.transform.AutoClone
+import groovy.transform.CompileStatic
+import org.grails.datastore.mapping.model.MappingContext
+import org.grails.gorm.graphql.entity.dsl.helpers.*
+import org.grails.gorm.graphql.entity.property.GraphQLDomainProperty
+import org.grails.gorm.graphql.fetcher.impl.ClosureDataFetcher
+import org.grails.gorm.graphql.types.GraphQLPropertyType
+import org.grails.gorm.graphql.types.GraphQLTypeManager
+
+/**
+ * Implementation of {@link GraphQLDomainProperty} to be used for defining custom union properties
+ *
+ * @author James Hardwick
+ * @since 2.0.2
+ */
+@AutoClone
+@CompileStatic
+abstract class UnionGraphQLProperty<T> extends OrderedGraphQLProperty implements Named<T>, Describable<T>, Deprecatable<T>, Nullable<T>, Arguable<T> {
+
+    Integer order = null
+    boolean input = false
+    boolean output = true
+    Closure closureDataFetcher = null
+    boolean collection = false
+
+    T collection(boolean collection) {
+        this.collection = collection
+        (T)this
+    }
+
+    T dataFetcher(Closure dataFetcher) {
+        this.closureDataFetcher = dataFetcher
+        (T)this
+    }
+    
+    T order(Integer order) {
+        this.order = order
+        (T)this
+    }
+    
+    //should be set by the property manager
+    protected MappingContext mappingContext
+
+    void setMappingContext(MappingContext mappingContext) {
+        this.mappingContext = mappingContext
+    }
+
+    @Override
+    abstract GraphQLType getGraphQLType(GraphQLTypeManager typeManager, GraphQLPropertyType propertyType)
+
+    abstract Set<GraphQLType> getUnionTypes()
+
+    DataFetcher getDataFetcher() {
+        closureDataFetcher ? new ClosureDataFetcher(closureDataFetcher) : null
+    }
+
+    void validate() {
+        if (name == null) {
+            throw new IllegalArgumentException('A name is required for creating custom properties')
+        }
+    }
+
+}

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/UnionGraphQLProperty.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/UnionGraphQLProperty.groovy
@@ -19,7 +19,7 @@ import org.grails.gorm.graphql.types.GraphQLTypeManager
  */
 @AutoClone
 @CompileStatic
-abstract class UnionGraphQLProperty<T> extends OrderedGraphQLProperty implements Named<T>, Describable<T>, Deprecatable<T>, Nullable<T>, Arguable<T> {
+abstract class UnionGraphQLProperty<T> extends OrderedGraphQLProperty implements Named<T>, Describable<T>, Deprecatable<T>, Nullable<T> {
 
     Integer order = null
     boolean input = false

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/property/manager/DefaultGraphQLDomainPropertyManager.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/property/manager/DefaultGraphQLDomainPropertyManager.groovy
@@ -10,6 +10,7 @@ import org.grails.gorm.graphql.entity.dsl.GraphQLMapping
 import org.grails.gorm.graphql.entity.dsl.GraphQLPropertyMapping
 import org.grails.gorm.graphql.entity.property.GraphQLDomainProperty
 import org.grails.gorm.graphql.entity.property.impl.CustomGraphQLProperty
+import org.grails.gorm.graphql.entity.property.impl.UnionGraphQLProperty
 import org.grails.gorm.graphql.entity.property.impl.PersistentGraphQLProperty
 
 import java.lang.reflect.Method
@@ -161,6 +162,19 @@ class DefaultGraphQLDomainPropertyManager implements GraphQLDomainPropertyManage
                 else {
                     prop = property
                 }
+                prop.mappingContext = mappingContext
+                properties.add(prop)
+            }
+
+            for (UnionGraphQLProperty property: mapping.additionalUnions) {
+                UnionGraphQLProperty prop
+                if (overrideNullable && !property.nullable) {
+                    prop = (UnionGraphQLProperty)property.clone().nullable(true)
+                }
+                else {
+                    prop = property
+                }
+
                 prop.mappingContext = mappingContext
                 properties.add(prop)
             }

--- a/core/src/main/groovy/org/grails/gorm/graphql/testing/MockDataFetchingEnvironment.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/testing/MockDataFetchingEnvironment.groovy
@@ -60,7 +60,7 @@ class MockDataFetchingEnvironment implements DataFetchingEnvironment {
 
     @Override
     Object getArgumentOrDefault(String name, Object defaultValue) {
-        return arguments.getOrDefault(name, defaultValue)
+        arguments.getOrDefault(name, defaultValue)
     }
 
     @Override

--- a/examples/grails-test-app/grails-app/domain/grails/test/app/unions/Guardian.groovy
+++ b/examples/grails-test-app/grails-app/domain/grails/test/app/unions/Guardian.groovy
@@ -1,5 +1,8 @@
 package grails.test.app.unions
 
+
+import grails.test.app.inheritance.Human
+import grails.test.app.inheritance.Labradoodle
 import org.grails.gorm.graphql.entity.dsl.GraphQLMapping
 import org.grails.gorm.graphql.fetcher.impl.ClosureDataFetchingEnvironment
 
@@ -26,6 +29,12 @@ class Guardian {
                     new Cat(name: 'Garfield', lives: 9),
                     new Pup(name: 'Scooby', bones: 50)
                 ]
+            }
+        }
+        addUnion('random', 'TotallyDifferent', [Labradoodle, Human]) {
+            collection(true)
+            dataFetcher { Guardian source, ClosureDataFetchingEnvironment env ->
+                return Labradoodle.list() + Human.list()
             }
         }
     }

--- a/examples/grails-test-app/grails-app/domain/grails/test/app/unions/Guardian.groovy
+++ b/examples/grails-test-app/grails-app/domain/grails/test/app/unions/Guardian.groovy
@@ -1,0 +1,33 @@
+package grails.test.app.unions
+
+import org.grails.gorm.graphql.entity.dsl.GraphQLMapping
+import org.grails.gorm.graphql.fetcher.impl.ClosureDataFetchingEnvironment
+
+class Guardian {
+
+    String name
+
+    static constraints = {
+    }
+
+    static graphql = GraphQLMapping.build {
+        addUnion('pets', 'Pets') {
+            collection(true)
+            type(Cat) {
+                field('name', String)
+                field('lives', Integer)
+            }
+            type(Pup) {
+                field('name', String)
+                field('bones', Integer)
+            }
+            dataFetcher { Guardian source, ClosureDataFetchingEnvironment env ->
+                return [
+                    new Cat(name: 'Garfield', lives: 9),
+                    new Pup(name: 'Scooby', bones: 50)
+                ]
+            }
+        }
+    }
+}
+

--- a/examples/grails-test-app/grails-app/init/grails/test/app/BootStrap.groovy
+++ b/examples/grails-test-app/grails-app/init/grails/test/app/BootStrap.groovy
@@ -8,9 +8,12 @@ class BootStrap {
     DogService dogService
     LabradoodleService labradoodleService
     HumanService humanService
+    GuardianService guardianService
     GrailsTeamMemberService grailsTeamMemberService
 
     def init = { servletContext ->
+
+        guardianService.save("Martha")
 
         dogService.save("Spot", 60)
         labradoodleService.save("Chloe", 60)

--- a/examples/grails-test-app/grails-app/services/grails/test/app/GuardianService.groovy
+++ b/examples/grails-test-app/grails-app/services/grails/test/app/GuardianService.groovy
@@ -1,0 +1,10 @@
+package grails.test.app
+
+import grails.gorm.services.Service
+import grails.test.app.inheritance.Dog
+import grails.test.app.unions.Guardian
+
+@Service(Guardian)
+interface GuardianService {
+    Guardian save(String name)
+}

--- a/examples/grails-test-app/src/integration-test/groovy/grails/test/app/UnionIntegrationSpec.groovy
+++ b/examples/grails-test-app/src/integration-test/groovy/grails/test/app/UnionIntegrationSpec.groovy
@@ -1,0 +1,37 @@
+package grails.test.app
+
+import grails.testing.mixin.integration.Integration
+import org.grails.gorm.graphql.plugin.testing.GraphQLSpec
+import spock.lang.Specification
+
+@Integration
+class UnionIntegrationSpec extends Specification implements GraphQLSpec {
+
+    void "custom union collection property"() {
+        when:
+        def resp = graphQL.graphql("""
+            {
+                guardianList {
+                    id
+                    name
+                    pets {
+                        __typename
+                        ... on Pup {
+                            name
+                            bones
+                        }
+                        ... on Cat {
+                            name
+                            lives
+                        }
+                    }
+                }
+            }
+        """, String.class)
+        String data = resp.getBody().get()
+
+        then:
+        data == '{"data":{"guardianList":[{"id":1,"name":"Martha","pets":[{"__typename":"Cat","name":"Garfield","lives":9},{"__typename":"Pup","name":"Scooby","bones":50}]}]}}'
+    }
+
+}

--- a/examples/grails-test-app/src/integration-test/groovy/grails/test/app/UnionIntegrationSpec.groovy
+++ b/examples/grails-test-app/src/integration-test/groovy/grails/test/app/UnionIntegrationSpec.groovy
@@ -34,4 +34,30 @@ class UnionIntegrationSpec extends Specification implements GraphQLSpec {
         data == '{"data":{"guardianList":[{"id":1,"name":"Martha","pets":[{"__typename":"Cat","name":"Garfield","lives":9},{"__typename":"Pup","name":"Scooby","bones":50}]}]}}'
     }
 
+    void "simple union collection property"() {
+        when:
+        def resp = graphQL.graphql("""
+            {
+                guardianList {
+                    id
+                    name
+                    random {
+                        __typename
+                        ... on Labradoodle {
+                            name
+                            barks
+                        }
+                        ... on Human {
+                            name
+                            language
+                        }
+                    }
+                }
+            }
+        """, String.class)
+        String data = resp.getBody().get()
+
+        then:
+        data == '{"data":{"guardianList":[{"id":1,"name":"Martha","random":[{"__typename":"Labradoodle","name":"Chloe","barks":true},{"__typename":"Human","name":"Kotlin Ken","language":true}]}]}}'
+    }
 }

--- a/examples/grails-test-app/src/main/groovy/grails/test/app/unions/Cat.groovy
+++ b/examples/grails-test-app/src/main/groovy/grails/test/app/unions/Cat.groovy
@@ -1,0 +1,6 @@
+package grails.test.app.unions
+
+class Cat {
+    String name
+    Integer lives
+}

--- a/examples/grails-test-app/src/main/groovy/grails/test/app/unions/Pup.groovy
+++ b/examples/grails-test-app/src/main/groovy/grails/test/app/unions/Pup.groovy
@@ -1,0 +1,6 @@
+package grails.test.app.unions
+
+class Pup {
+    String name
+    Integer bones
+}


### PR DESCRIPTION
I had a use case which finally warranted using Unions, so I went ahead and took a pass at implementing them. 

A couple things of note: 
- I split apart the ComplexType trait into CustomType/ComplexType, since I wanted to utilize it for the types contained by a union but those types cannot be of type collection. So all other "simple" features continue to use ComplexType but unions use CustomType.
- I couldn't think of a form of the `add` GraphQLMapping that would fit with unions so I just included it as `addUnion`.

Still needs a bit more testing and docs, but was curious to get any feedback.