### PR TITLE
Property Arguments

### DIFF
--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/dsl/GraphQLPropertyMapping.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/dsl/GraphQLPropertyMapping.groovy
@@ -3,10 +3,9 @@ package org.grails.gorm.graphql.entity.dsl
 import groovy.transform.CompileStatic
 import groovy.transform.builder.Builder
 import groovy.transform.builder.SimpleStrategy
-import org.grails.gorm.graphql.entity.dsl.helpers.Arguable
+import org.grails.gorm.graphql.entity.dsl.helpers.Argued
 import org.grails.gorm.graphql.entity.dsl.helpers.Deprecatable
 import org.grails.gorm.graphql.entity.dsl.helpers.Describable
-import org.grails.gorm.graphql.entity.dsl.helpers.ExecutesClosures
 import org.grails.gorm.graphql.entity.dsl.helpers.Named
 
 /**
@@ -39,7 +38,7 @@ import org.grails.gorm.graphql.entity.dsl.helpers.Named
  */
 @Builder(builderStrategy = SimpleStrategy, prefix = '')
 @CompileStatic
-class GraphQLPropertyMapping implements Describable<GraphQLPropertyMapping>, Deprecatable<GraphQLPropertyMapping>, Named<GraphQLPropertyMapping>, Arguable<GraphQLPropertyMapping> {
+class GraphQLPropertyMapping implements Describable<GraphQLPropertyMapping>, Deprecatable<GraphQLPropertyMapping>, Named<GraphQLPropertyMapping>, Argued<GraphQLPropertyMapping> {
 
     /**
      * Whether or not the property should be available to

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/dsl/GraphQLPropertyMapping.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/dsl/GraphQLPropertyMapping.groovy
@@ -3,6 +3,7 @@ package org.grails.gorm.graphql.entity.dsl
 import groovy.transform.CompileStatic
 import groovy.transform.builder.Builder
 import groovy.transform.builder.SimpleStrategy
+import org.grails.gorm.graphql.entity.dsl.helpers.Arguable
 import org.grails.gorm.graphql.entity.dsl.helpers.Deprecatable
 import org.grails.gorm.graphql.entity.dsl.helpers.Describable
 import org.grails.gorm.graphql.entity.dsl.helpers.ExecutesClosures
@@ -38,7 +39,7 @@ import org.grails.gorm.graphql.entity.dsl.helpers.Named
  */
 @Builder(builderStrategy = SimpleStrategy, prefix = '')
 @CompileStatic
-class GraphQLPropertyMapping implements Describable<GraphQLPropertyMapping>, Deprecatable<GraphQLPropertyMapping>, Named<GraphQLPropertyMapping>, ExecutesClosures {
+class GraphQLPropertyMapping implements Describable<GraphQLPropertyMapping>, Deprecatable<GraphQLPropertyMapping>, Named<GraphQLPropertyMapping>, Arguable<GraphQLPropertyMapping> {
 
     /**
      * Whether or not the property should be available to

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/dsl/helpers/Arguable.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/dsl/helpers/Arguable.groovy
@@ -9,69 +9,25 @@ import org.grails.gorm.graphql.entity.arguments.SimpleArgument
 import org.grails.gorm.graphql.types.GraphQLTypeManager
 
 /**
- * Decorates a class with a description property and builder method.
+ * Decorates a class w/ support for GraphQLArguments
  *
- * @param <T> The implementing class
  * @author James Kleeh
- * @since 1.0.0
+ * @since 2.0.2
  */
 @CompileStatic
-trait Arguable<T> extends ExecutesClosures {
+trait Arguable extends ExecutesClosures {
 
     List<CustomArgument> arguments = []
 
-    private void handleArgumentClosure(CustomArgument argument, Closure closure) {
-        withDelegate(closure, (Object)argument)
-        argument.validate()
-        arguments.add(argument)
-    }
-
+    /**
+     * @param typeManager The returnType manager used to retrieve GraphQL types
+     * @param mappingContext The GORM datastore mapping context used for retrieving information on entities
+     * @return A collection of GraphQLArgument's, if any are defined
+     */
     List<GraphQLArgument> getArguments(GraphQLTypeManager typeManager, MappingContext mappingContext) {
         arguments.collect {
             it.getArgument(typeManager, mappingContext).build()
         }
-    }
-
-    /**
-     * Creates an argument to the operation that is a list of a simple type.
-     * The list can not have more than 1 element and that element must be a class.
-     *
-     * @param name The name of the argument
-     * @param type The returnType of the argument
-     * @param closure To provide additional data about the argument
-     * @return The operation in order to chain method calls
-     */
-    T argument(String name, List<Class<?>> type, @DelegatesTo(value = SimpleArgument, strategy = Closure.DELEGATE_ONLY) Closure closure = null) {
-        CustomArgument argument = new SimpleArgument().name(name).returns(type)
-        handleArgumentClosure(argument, closure)
-        (T)this
-    }
-
-    /**
-     * Creates an argument to the operation that is of the returnType provided.
-     *
-     * @param name The name of the argument
-     * @param type The returnType of the argument
-     * @param closure To provide additional data about the argument
-     * @return The operation in order to chain method calls
-     */
-    T argument(String name, Class<?> type, @DelegatesTo(value = SimpleArgument, strategy = Closure.DELEGATE_ONLY) Closure closure = null) {
-        CustomArgument argument = new SimpleArgument().name(name).returns(type)
-        handleArgumentClosure(argument, closure)
-        (T)this
-    }
-
-    /**
-     * Creates an argument to the operation that is a custom type.
-     *
-     * @param name The name of the argument
-     * @param closure To provide additional data about the argument
-     * @return The operation in order to chain method calls
-     */
-    T argument(String name, String typeName, @DelegatesTo(value = ComplexArgument, strategy = Closure.DELEGATE_ONLY) Closure closure) {
-        CustomArgument argument = new ComplexArgument().name(name).typeName(typeName)
-        handleArgumentClosure(argument, closure)
-        (T)this
     }
 
 }

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/dsl/helpers/Argued.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/dsl/helpers/Argued.groovy
@@ -1,0 +1,66 @@
+package org.grails.gorm.graphql.entity.dsl.helpers
+
+import groovy.transform.CompileStatic
+import org.grails.gorm.graphql.entity.arguments.ComplexArgument
+import org.grails.gorm.graphql.entity.arguments.CustomArgument
+import org.grails.gorm.graphql.entity.arguments.SimpleArgument
+
+/**
+ * Decorates a class with argument builders.
+ *
+ * @param <T> The implementing class
+ * @author James Kleeh
+ * @since 2.0.2
+ */
+@CompileStatic
+trait Argued<T> extends Arguable {
+
+    private void handleArgumentClosure(CustomArgument argument, Closure closure) {
+        withDelegate(closure, (Object)argument)
+        argument.validate()
+        arguments.add(argument)
+    }
+
+    /**
+     * Creates an argument to the operation that is a list of a simple type.
+     * The list can not have more than 1 element and that element must be a class.
+     *
+     * @param name The name of the argument
+     * @param type The returnType of the argument
+     * @param closure To provide additional data about the argument
+     * @return The operation in order to chain method calls
+     */
+    T argument(String name, List<Class<?>> type, @DelegatesTo(value = SimpleArgument, strategy = Closure.DELEGATE_ONLY) Closure closure = null) {
+        CustomArgument argument = new SimpleArgument().name(name).returns(type)
+        handleArgumentClosure(argument, closure)
+        (T)this
+    }
+
+    /**
+     * Creates an argument to the operation that is of the returnType provided.
+     *
+     * @param name The name of the argument
+     * @param type The returnType of the argument
+     * @param closure To provide additional data about the argument
+     * @return The operation in order to chain method calls
+     */
+    T argument(String name, Class<?> type, @DelegatesTo(value = SimpleArgument, strategy = Closure.DELEGATE_ONLY) Closure closure = null) {
+        CustomArgument argument = new SimpleArgument().name(name).returns(type)
+        handleArgumentClosure(argument, closure)
+        (T)this
+    }
+
+    /**
+     * Creates an argument to the operation that is a custom type.
+     *
+     * @param name The name of the argument
+     * @param closure To provide additional data about the argument
+     * @return The operation in order to chain method calls
+     */
+    T argument(String name, String typeName, @DelegatesTo(value = ComplexArgument, strategy = Closure.DELEGATE_ONLY) Closure closure) {
+        CustomArgument argument = new ComplexArgument().name(name).typeName(typeName)
+        handleArgumentClosure(argument, closure)
+        (T)this
+    }
+
+}

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/operations/CustomOperation.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/operations/CustomOperation.groovy
@@ -5,12 +5,11 @@ import groovy.transform.CompileStatic
 import org.grails.datastore.mapping.model.MappingContext
 import org.grails.datastore.mapping.model.PersistentEntity
 import org.grails.gorm.graphql.GraphQLServiceManager
-import org.grails.gorm.graphql.entity.dsl.helpers.Arguable
+import org.grails.gorm.graphql.entity.arguments.CustomArgument
+import org.grails.gorm.graphql.entity.dsl.helpers.Argued
 import org.grails.gorm.graphql.entity.dsl.helpers.Deprecatable
 import org.grails.gorm.graphql.entity.dsl.helpers.Describable
-import org.grails.gorm.graphql.entity.dsl.helpers.ExecutesClosures
 import org.grails.gorm.graphql.entity.dsl.helpers.Named
-import org.grails.gorm.graphql.entity.arguments.CustomArgument
 import org.grails.gorm.graphql.fetcher.interceptor.CustomMutationInterceptorInvoker
 import org.grails.gorm.graphql.fetcher.interceptor.CustomQueryInterceptorInvoker
 import org.grails.gorm.graphql.fetcher.interceptor.InterceptingDataFetcher
@@ -28,7 +27,7 @@ import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition
  * @since 1.0.0
  */
 @CompileStatic
-abstract class CustomOperation<T> implements Named<T>, Describable<T>, Deprecatable<T>, Arguable<T>, ExecutesClosures {
+abstract class CustomOperation<T> implements Named<T>, Describable<T>, Deprecatable<T>, Argued<T> {
 
     private static InterceptorInvoker queryInvoker = new CustomQueryInterceptorInvoker()
     private static InterceptorInvoker mutationInvoker = new CustomMutationInterceptorInvoker()

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/property/GraphQLDomainProperty.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/property/GraphQLDomainProperty.groovy
@@ -2,6 +2,7 @@ package org.grails.gorm.graphql.entity.property
 
 import graphql.schema.DataFetcher
 import graphql.schema.GraphQLType
+import org.grails.gorm.graphql.entity.dsl.helpers.Arguable
 import org.grails.gorm.graphql.types.GraphQLPropertyType
 import org.grails.gorm.graphql.types.GraphQLTypeManager
 
@@ -12,7 +13,7 @@ import org.grails.gorm.graphql.types.GraphQLTypeManager
  * @author James Kleeh
  * @since 1.0.0
  */
-interface GraphQLDomainProperty {
+interface GraphQLDomainProperty extends Arguable {
 
     /**
      * @return The name of the property

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/CustomGraphQLProperty.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/CustomGraphQLProperty.groovy
@@ -5,15 +5,12 @@ import graphql.schema.GraphQLType
 import groovy.transform.AutoClone
 import groovy.transform.CompileStatic
 import org.grails.datastore.mapping.model.MappingContext
-import org.grails.gorm.graphql.entity.dsl.helpers.Arguable
-import org.grails.gorm.graphql.entity.dsl.helpers.Deprecatable
-import org.grails.gorm.graphql.entity.dsl.helpers.Describable
-import org.grails.gorm.graphql.entity.dsl.helpers.Named
-import org.grails.gorm.graphql.entity.dsl.helpers.Nullable
+import org.grails.gorm.graphql.entity.dsl.helpers.*
 import org.grails.gorm.graphql.entity.property.GraphQLDomainProperty
 import org.grails.gorm.graphql.fetcher.impl.ClosureDataFetcher
 import org.grails.gorm.graphql.types.GraphQLPropertyType
 import org.grails.gorm.graphql.types.GraphQLTypeManager
+
 
 /**
  * Implementation of {@link GraphQLDomainProperty} to be used to define
@@ -24,7 +21,7 @@ import org.grails.gorm.graphql.types.GraphQLTypeManager
  */
 @AutoClone
 @CompileStatic
-abstract class CustomGraphQLProperty<T> extends OrderedGraphQLProperty implements Named<T>, Describable<T>, Deprecatable<T>, Nullable<T>, Arguable<T> {
+abstract class CustomGraphQLProperty<T> extends OrderedGraphQLProperty implements Named<T>, Describable<T>, Deprecatable<T>, Nullable<T>, Argued<T> {
 
     Integer order = null
     boolean input = true

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/OrderedGraphQLProperty.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/OrderedGraphQLProperty.groovy
@@ -1,6 +1,7 @@
 package org.grails.gorm.graphql.entity.property.impl
 
 import groovy.transform.CompileStatic
+import org.grails.gorm.graphql.entity.dsl.helpers.Arguable
 import org.grails.gorm.graphql.entity.property.GraphQLDomainProperty
 
 /**
@@ -11,7 +12,7 @@ import org.grails.gorm.graphql.entity.property.GraphQLDomainProperty
  * @since 1.0.0
  */
 @CompileStatic
-abstract class OrderedGraphQLProperty implements GraphQLDomainProperty, Comparable<OrderedGraphQLProperty> {
+abstract class OrderedGraphQLProperty implements GraphQLDomainProperty, Arguable, Comparable<OrderedGraphQLProperty> {
 
     abstract Integer getOrder()
 

--- a/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/PersistentGraphQLProperty.groovy
+++ b/core/src/main/groovy/org/grails/gorm/graphql/entity/property/impl/PersistentGraphQLProperty.groovy
@@ -67,6 +67,7 @@ class PersistentGraphQLProperty extends OrderedGraphQLProperty {
         }
         this.output = mapping.output
         this.input = mapping.input
+        this.arguments.addAll(mapping.arguments)
         this.dataFetcher = mapping.dataFetcher ? new ClosureDataFetcher(mapping.dataFetcher) : new PersistentPropertyDataFetcher((PersistentProperty) property)
         if (mapping.order != null) {
             this.order = mapping.order

--- a/core/src/test/groovy/org/grails/gorm/graphql/entity/dsl/GraphQLPropertyMappingSpec.groovy
+++ b/core/src/test/groovy/org/grails/gorm/graphql/entity/dsl/GraphQLPropertyMappingSpec.groovy
@@ -12,6 +12,7 @@ class GraphQLPropertyMappingSpec extends Specification {
             deprecated true
             deprecationReason 'reason'
             description 'description'
+            argument 'argument', [String]
             dataFetcher {
 
             }
@@ -23,6 +24,8 @@ class GraphQLPropertyMappingSpec extends Specification {
         mapping.deprecated
         mapping.deprecationReason == 'reason'
         mapping.description == 'description'
+        mapping.arguments.size() == 1
+        mapping.arguments.first().name == 'argument'
         mapping.dataFetcher instanceof Closure
     }
 }

--- a/examples/grails-test-app/grails-app/domain/grails/test/app/ArguedField.groovy
+++ b/examples/grails-test-app/grails-app/domain/grails/test/app/ArguedField.groovy
@@ -40,5 +40,12 @@ class ArguedField {
                 ping["payload"]
             }
         }
+        property('name') {
+            argument('isUppercase', Boolean)
+            dataFetcher { ArguedField af, ClosureDataFetchingEnvironment env ->
+                Boolean isUpper = env.getArgument('isUppercase')
+                isUpper ? af.name.toUpperCase() : af.name
+            }
+        }
     }
 }

--- a/examples/grails-test-app/src/integration-test/groovy/grails/test/app/ArguedFieldIntegrationSpec.groovy
+++ b/examples/grails-test-app/src/integration-test/groovy/grails/test/app/ArguedFieldIntegrationSpec.groovy
@@ -64,4 +64,19 @@ class ArguedFieldIntegrationSpec extends Specification implements GraphQLSpec {
         obj.withCustomArgument == "PONG"
     }
 
+    void "test a property argument"() {
+        when:
+        def resp = graphQL.graphql("""
+            {
+              arguedField(id: ${grailsId}) {
+                  name(isUppercase: true)
+              }
+            }
+        """)
+        def obj = resp.body().data.arguedField
+
+        then:
+        obj.name == "TEST"
+    }
+
 }


### PR DESCRIPTION
Adds support for providing arguments to overridden properties, allowing us to support modifying the returned result within the dataFetcher. 

We already had the ability to customize a GORM properties schema definition, this just takes it a bit further and puts it on par w/ custom fields. 

Still need to add some docs and probably should add a test that exhibits the query difference that I referred to above, but this should be a good start.