### PR TITLE
chore(build): Add missing build files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,88 @@
+buildscript {
+    repositories {
+        maven { url "https://repo.grails.org/grails/core" }
+    }
+    dependencies {
+        classpath "org.grails:grails-gradle-plugin:$grailsGradlePluginVersion"
+        classpath "org.grails.plugins:views-gradle:$viewGradleVersion"
+        classpath "org.grails.plugins:views-json:$viewsJsonVersion"
+        classpath "org.grails:grails-docs:${project.ext.properties.grailsDocsVersion ?: grailsVersion}"
+        classpath "io.github.gradle-nexus:publish-plugin:1.3.0"
+    }
+}
+
+repositories {
+    mavenCentral()
+    maven { url "https://repo.grails.org/grails/core" }
+}
+
+version project.projectVersion
+
+ext {
+    commonBuild = 'https://raw.githubusercontent.com/grails/grails-common-build/v2.0.1'
+}
+
+subprojects {
+
+    version project.projectVersion
+
+    ext {
+        userOrg = "grails"
+        isGrailsPlugin = name.startsWith('grails-plugin')
+        isBuildSnapshot = version.toString().endsWith("-SNAPSHOT")
+    }
+
+    repositories {
+        maven { url "https://repo.grails.org/grails/core" }
+    }
+
+    tasks.withType(GroovyCompile).configureEach {
+        configure(groovyOptions) {
+            forkOptions.jvmArgs = ['-Xmx1024m']
+        }
+    }
+
+    tasks.withType(Test).configureEach {
+        testLogging {
+            events "failed"
+            exceptionFormat "full"
+            showStandardStreams true
+        }
+    }
+
+    if (project.name.startsWith("examples-")) {
+        if (project.name.startsWith("examples-grails-")) {
+            apply plugin: "org.grails.grails-web"
+        }
+        return
+    }
+
+    if (isGrailsPlugin) {
+        group "org.grails.plugins"
+    } else {
+        group "org.grails"
+    }
+
+    if (isGrailsPlugin) {
+        apply plugin: 'groovy'
+        apply plugin: 'eclipse'
+        apply plugin: 'idea'
+        apply plugin: 'java-library'
+        apply plugin: "org.grails.grails-plugin"
+
+        sourceCompatibility = 1.11
+        targetCompatibility = 1.11
+    } else {
+        apply from: "${commonBuild}/common-project.gradle"
+    }
+
+    dependencies {
+        implementation "com.graphql-java:graphql-java:$graphqlJavaVersion"
+        testImplementation "org.codehaus.groovy:groovy-test:$groovyVersion"
+        testImplementation "io.projectreactor:reactor-test:3.6.1"
+        testImplementation("org.spockframework:spock-core:$spockVersion")
+        implementation 'org.grails:grails-datastore-gorm:7.3.4'
+    }
+}
+
+apply from: "${commonBuild}/common-publishing.gradle"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,36 @@
+title=GORM GraphQL
+authors=James Kleeh
+projectVersion=4.0.0-SNAPSHOT
+projectDesc=Generates a GraphQL schema based on entities in GORM
+projectUrl=https://github.com/grails/gorm-graphql
+githubSlug=grails/gorm-graphql
+githubBranch=2.0.x
+developers=James Kleeh
+gormVersion=7.3.4
+gormHibernateVersion=7.3.1
+gormMongoDbVersion=7.0.0.RELEASE
+grailsVersion=6.1.0
+grailsGradlePluginVersion=6.1.1
+grailsDocsVersion=3.3.2
+groovyVersion=3.0.11
+junitJupiterVersion=5.9.3
+slf4jVersion=1.7.36
+spockVersion=2.1-groovy-3.0
+micronautVersion=3.10.3
+graphqlJavaVersion=20.7
+graphqlJavaScalarExtVersion=20.2
+codenarcVersion=3.3.0
+viewGradleVersion=2.3.2
+viewsJsonVersion=2.3.2
+servletApiVersion=4.0.1
+cglibNodepVersion=3.2.9
+objenesisVersion=3.3
+jansiVersion=2.4.1
+hibernateEcacheVersion=5.6.7.Final
+hibernateCoreVersion=5.6.11.Final
+org.gradle.daemon=true
+org.gradle.parallel=true
+org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1024M
+
+
+


### PR DESCRIPTION
Currently, CI is broken on branch `4.0.x`.

> [![Java CI](https://github.com/grails/gorm-graphql/actions/workflows/gradle.yml/badge.svg?branch=4.0.x)](https://github.com/grails/gorm-graphql/actions/runs/7804903679/job/21287887437)
>
> ```
> * What went wrong:
> A problem occurred evaluating project ':docs'.
> > Could not get unknown property 'groovyVersion' for object of type 
> org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
> ```

I believe the cause of the problem is that some Gradle files were accidentally deleted due to a [merge conflict](https://github.com/grails/gorm-graphql/commit/fd21fbfc3a1e7649d4e24b8cd4bb847db2be8f56).

